### PR TITLE
fix(render): support D3D11 embedded overlay and repair platform shell

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -952,6 +952,45 @@ target_compile_options(anomaly_render_fixture PRIVATE /W4 /permissive- /EHsc)
 target_link_libraries(
     anomaly_render_fixture PRIVATE anomaly_runtime_kernel d3d12 dxgi dxguid)
 
+# Exercises the Present interception path against a D3D11 swap chain, which is
+# what a title using the D3D11 RHI presents. Nothing covered that path before,
+# which is how an overlay that only knew how to draw with D3D12 could sit in a
+# D3D11 game reporting nothing but "waiting for a command queue". The fixture
+# owns the window, device and swap chain; everything above it is the real
+# embedded platform, hooks included.
+add_executable(anomaly_d3d11_fixture
+    apps/render_fixture/d3d11_embedded_fixture.cpp
+    src/ui/platform_host.cpp
+    "${PLATFORM_UI_RESOURCES_RC}"
+    src/render/dx12/embedded_bridge.cpp
+    src/render/dx12/embedded_discovery.cpp
+    src/render/dx12/embedded_input.cpp
+    src/render/dx12/embedded_renderer.cpp
+    src/render/dx12/embedded_ui_resource_render_backend.cpp
+    src/ui/embedded_ui.cpp
+    src/game/nte/nte_esc_menu_bridge.cpp
+    src/plugin/plugin_manager.cpp)
+set_target_properties(anomaly_d3d11_fixture PROPERTIES OUTPUT_NAME "anomaly-d3d11-fixture")
+target_include_directories(anomaly_d3d11_fixture PRIVATE include src "${GENERATED_DIR}")
+target_compile_definitions(
+    anomaly_d3d11_fixture PRIVATE UNICODE _UNICODE WIN32_LEAN_AND_MEAN NOMINMAX)
+target_compile_options(anomaly_d3d11_fixture PRIVATE /W4 /permissive- /EHsc)
+target_link_libraries(
+    anomaly_d3d11_fixture PRIVATE
+    ue5mem_core anomaly_runtime_kernel anomaly_imgui anomaly_minhook_backend anomaly_ui_service
+    anomaly_platform_ui_model
+    anomaly_platform_settings
+    anomaly_scoped_platform
+    anomaly_plugin_shadow anomaly_plugin_dependency_resolver anomaly_plugin_enablement
+    anomaly_nte_profile_runtime
+    anomaly_websocket_server
+    anomaly_repository_coordinator
+    anomaly_crash_reporter anomaly_runtime_crash_coordinator
+    anomaly_structured_logger anomaly_ui_resources anomaly_i18n
+    anomaly_adapter_services anomaly_plugin_runtime
+    nlohmann_json::nlohmann_json d3d11 d3d12 dxgi dxguid)
+add_dependencies(anomaly_d3d11_fixture anomaly_stage_nte_profiles)
+
 option(ANOMALY_BUILD_SDK_EXAMPLES "Build the Anomaly 1.0 SDK example plugins" ON)
 option(ANOMALY_BUILD_BUILTIN_PLUGINS "Build Anomaly bundled plugins" ON)
 set(ANOMALY_PLATFORM_PREVIEW_STAGE_COMMANDS

--- a/apps/render_fixture/d3d11_embedded_fixture.cpp
+++ b/apps/render_fixture/d3d11_embedded_fixture.cpp
@@ -1,0 +1,308 @@
+// Drives the embedded overlay against a swap chain owned by a D3D11 device.
+//
+// The existing render fixture exercises the dispatcher; nothing exercised the
+// Present interception path, and nothing at all exercised it for D3D11. That
+// gap is why an overlay that only ever knew how to draw with D3D12 could sit in
+// a D3D11 title reporting nothing but "waiting for a command queue".
+//
+// The fixture stands in for the game: it owns the window, the device and the
+// swap chain, and it presents frames. Everything else is the real embedded
+// platform, hooks included.
+#include "anomaly/i18n.hpp"
+#include "anomaly/platform_settings.hpp"
+#include "anomaly/platform_ui_theme.hpp"
+
+#include "config.hpp"
+#include "platform_host.hpp"
+#include "plugin_manager.hpp"
+
+#include <Windows.h>
+
+#include <d3d11.h>
+#include <dxgi1_2.h>
+
+#include <atomic>
+#include <chrono>
+#include <condition_variable>
+#include <cstdio>
+#include <deque>
+#include <functional>
+#include <mutex>
+#include <string_view>
+#include <filesystem>
+#include <stop_token>
+#include <string>
+#include <thread>
+
+#pragma comment(lib, "d3d11.lib")
+#pragma comment(lib, "dxgi.lib")
+
+namespace {
+
+constexpr UINT kWidth = 1280;
+constexpr UINT kHeight = 720;
+
+// Counts clicks that reached the window standing in for the game.
+//
+// An overlay covering the whole client area has to let these through wherever it
+// is not drawing, and the only way to see that is from the other side: a click
+// the overlay swallowed never arrives here.
+std::atomic<int> g_target_clicks{};
+
+LRESULT CALLBACK FixtureWindowProc(HWND window, UINT message, WPARAM wparam, LPARAM lparam) {
+    if (message == WM_LBUTTONDOWN) g_target_clicks.fetch_add(1);
+    if (message == WM_DESTROY) {
+        PostQuitMessage(0);
+        return 0;
+    }
+    return DefWindowProcW(window, message, wparam, lparam);
+}
+
+std::filesystem::path ExecutableDirectory() {
+    std::wstring path(32768, L'\0');
+    const DWORD length =
+        GetModuleFileNameW(nullptr, path.data(), static_cast<DWORD>(path.size()));
+    path.resize(length);
+    return std::filesystem::path(path).parent_path();
+}
+
+// Clears to a recognisable colour so a screenshot can tell overlay pixels from
+// the fixture's own.
+constexpr float kSceneColor[4]{0.12f, 0.28f, 0.55f, 1.0f};
+
+}  // namespace
+
+// Stands in for the runtime's Worker execution domain.
+//
+// Texture payloads arrive encoded and are decoded off the render thread, so
+// without a dispatcher a requested image stays in its Auto format forever and
+// the upload path is never reached. The fixture needs one for the same reason
+// the game does: it is what makes an icon observable rather than absent.
+class FixtureWorker final {
+public:
+    [[nodiscard]] bool Post(std::function<void()> callback) {
+        if (!callback) return false;
+        {
+            std::scoped_lock lock(mutex_);
+            if (stopping_) return false;
+            queue_.push_back(std::move(callback));
+        }
+        signal_.notify_one();
+        return true;
+    }
+
+    void Run(std::stop_token stop_token) {
+        while (!stop_token.stop_requested()) {
+            std::function<void()> callback;
+            {
+                std::unique_lock lock(mutex_);
+                signal_.wait_for(lock, std::chrono::milliseconds(50),
+                    [&] { return stopping_ || !queue_.empty(); });
+                if (queue_.empty()) {
+                    if (stopping_) return;
+                    continue;
+                }
+                callback = std::move(queue_.front());
+                queue_.pop_front();
+            }
+            try { callback(); } catch (...) { }
+        }
+    }
+
+    void Stop() {
+        {
+            std::scoped_lock lock(mutex_);
+            stopping_ = true;
+        }
+        signal_.notify_all();
+    }
+
+private:
+    std::mutex mutex_;
+    std::condition_variable signal_;
+    std::deque<std::function<void()>> queue_;
+    bool stopping_{};
+};
+
+int main(int argc, char** argv) {
+    // "standalone" drives the other half of the same problem: the attached host
+    // window that sits over the game instead of drawing into its swap chain.
+    // Both modes need a real D3D11 window to sit on, and this fixture already
+    // owns one.
+    bool standalone = false;
+    for (int index = 1; index < argc; ++index) {
+        if (argv[index] != nullptr && std::string_view(argv[index]) == "standalone") {
+            standalone = true;
+        }
+    }
+    const HINSTANCE instance = GetModuleHandleW(nullptr);
+    WNDCLASSEXW window_class{
+        sizeof(WNDCLASSEXW), CS_CLASSDC, FixtureWindowProc, 0, 0, instance, nullptr, nullptr,
+        nullptr, nullptr, L"AnomalyD3D11Fixture", nullptr};
+    if (RegisterClassExW(&window_class) == 0) {
+        std::printf("fail RegisterClassExW %lu\n", GetLastError());
+        return 1;
+    }
+    RECT desired{0, 0, static_cast<LONG>(kWidth), static_cast<LONG>(kHeight)};
+    AdjustWindowRect(&desired, WS_OVERLAPPEDWINDOW, FALSE);
+    const HWND window = CreateWindowExW(
+        0, window_class.lpszClassName, L"Anomaly D3D11 Fixture", WS_OVERLAPPEDWINDOW, 80, 80,
+        desired.right - desired.left, desired.bottom - desired.top, nullptr, nullptr, instance,
+        nullptr);
+    if (window == nullptr) {
+        std::printf("fail CreateWindowExW %lu\n", GetLastError());
+        return 1;
+    }
+    ShowWindow(window, SW_SHOW);
+    UpdateWindow(window);
+
+    DXGI_SWAP_CHAIN_DESC swap_description{};
+    swap_description.BufferCount = 2;
+    swap_description.BufferDesc.Width = kWidth;
+    swap_description.BufferDesc.Height = kHeight;
+    // The game presents a ten bit back buffer, so match it: a format the
+    // overlay mishandles would otherwise only show up in the game.
+    swap_description.BufferDesc.Format = DXGI_FORMAT_R10G10B10A2_UNORM;
+    swap_description.BufferUsage = DXGI_USAGE_RENDER_TARGET_OUTPUT;
+    swap_description.OutputWindow = window;
+    swap_description.SampleDesc.Count = 1;
+    swap_description.Windowed = TRUE;
+    swap_description.SwapEffect = DXGI_SWAP_EFFECT_DISCARD;
+
+    ID3D11Device* device{};
+    ID3D11DeviceContext* context{};
+    IDXGISwapChain* swap_chain{};
+    const D3D_FEATURE_LEVEL levels[]{D3D_FEATURE_LEVEL_11_0, D3D_FEATURE_LEVEL_10_0};
+    D3D_FEATURE_LEVEL selected{};
+    HRESULT result = D3D11CreateDeviceAndSwapChain(
+        nullptr, D3D_DRIVER_TYPE_HARDWARE, nullptr, 0, levels, 2, D3D11_SDK_VERSION,
+        &swap_description, &swap_chain, &device, &selected, &context);
+    if (FAILED(result)) {
+        std::printf("fail D3D11CreateDeviceAndSwapChain 0x%08lX\n",
+                    static_cast<unsigned long>(result));
+        return 1;
+    }
+
+    const auto root = ExecutableDirectory() / L"Anomaly";
+    auto config = ue5mem::AnalyzerConfig::Load(root / L"anomaly.ini");
+    config.platform_enabled = true;
+    config.platform_visible = true;
+    config.platform_embedded = !standalone;
+    config.platform_attach_to_process_window = standalone;
+    const auto locale = anomaly::ResolveUserLocale(config.platform_language);
+    ue5mem::PlatformDiagnostics diagnostics;
+    diagnostics.runtime_root = root;
+    diagnostics.translator =
+        anomaly::LoadHostCatalog(locale.locale, root / L"locales" / L"host").translator;
+    auto worker = std::make_shared<FixtureWorker>();
+    std::stop_source worker_stop;
+    std::thread worker_thread([worker, token = worker_stop.get_token()] {
+        worker->Run(token);
+    });
+    auto plugins = std::make_shared<ue5mem::PluginManager>(
+        root, config.plugin_directory, anomaly::CoreMemoryServices{},
+        ue5mem::PluginCallbackBudgets{}, nullptr, anomaly::HotkeyDispatcher{},
+        [worker](std::string, std::uint64_t, std::function<void()> callback) -> bool {
+            return worker->Post(std::move(callback));
+        });
+    plugins->SetTranslator(diagnostics.translator);
+    plugins->LoadAll();
+    std::filesystem::create_directories(root / L"config");
+    auto settings = std::make_shared<anomaly::PlatformSettingsStore>(root);
+    static_cast<void>(settings->Start());
+    diagnostics.settings_snapshot = [settings] { return settings->Snapshot(); };
+
+    std::stop_source stop;
+    std::thread platform([&] {
+        // Embedded draws into the fixture's own swap chain; standalone puts an
+        // attached window over it. They are different entry points, not one
+        // function reading a flag.
+        if (standalone) {
+            ue5mem::RunPlatform(
+                root, config, stop.get_token(), {}, {}, diagnostics, plugins);
+        } else {
+            ue5mem::RunEmbeddedPlatform(
+                root, config, stop.get_token(), {}, {}, diagnostics, plugins);
+        }
+    });
+
+    // Give the bridge time to publish its state and install the DXGI hooks
+    // before the first Present arrives.
+    std::this_thread::sleep_for(std::chrono::milliseconds(1500));
+
+    ID3D11RenderTargetView* render_target{};
+    ID3D11Texture2D* back_buffer{};
+    if (SUCCEEDED(swap_chain->GetBuffer(0, IID_PPV_ARGS(&back_buffer)))) {
+        device->CreateRenderTargetView(back_buffer, nullptr, &render_target);
+        back_buffer->Release();
+    }
+
+    int presented = 0;
+    int resizes = 0;
+    UINT width = kWidth;
+    UINT height = kHeight;
+    // Standalone brings up a second window and attaches it, which takes longer
+    // to settle than drawing into a swap chain that is already presenting.
+    const auto deadline = std::chrono::steady_clock::now() +
+        std::chrono::seconds(standalone ? 30 : 12);
+    bool quit = false;
+    while (!quit && std::chrono::steady_clock::now() < deadline) {
+        MSG message{};
+        while (PeekMessageW(&message, nullptr, 0, 0, PM_REMOVE)) {
+            if (message.message == WM_QUIT) quit = true;
+            TranslateMessage(&message);
+            DispatchMessageW(&message);
+        }
+        // Two resizes part way through. A game does this on every alt-tab and
+        // resolution change, and the overlay has to drop its view of the back
+        // buffer first or ResizeBuffers fails outright.
+        if ((presented == 240 || presented == 420) && resizes < 2) {
+            ++resizes;
+            width = presented == 240 ? 1024u : kWidth;
+            height = presented == 240 ? 640u : kHeight;
+            if (render_target != nullptr) {
+                context->OMSetRenderTargets(0, nullptr, nullptr);
+                render_target->Release();
+                render_target = nullptr;
+            }
+            const HRESULT resized = swap_chain->ResizeBuffers(
+                0, width, height, DXGI_FORMAT_UNKNOWN, 0);
+            std::printf(
+                "resize %d -> %ux%u hr=0x%08lX\n", resizes, width, height,
+                static_cast<unsigned long>(resized));
+            if (FAILED(resized)) break;
+            if (SUCCEEDED(swap_chain->GetBuffer(0, IID_PPV_ARGS(&back_buffer)))) {
+                device->CreateRenderTargetView(back_buffer, nullptr, &render_target);
+                back_buffer->Release();
+                back_buffer = nullptr;
+            }
+        }
+        if (render_target != nullptr) {
+            context->OMSetRenderTargets(1, &render_target, nullptr);
+            context->ClearRenderTargetView(render_target, kSceneColor);
+        }
+        const HRESULT present = swap_chain->Present(1, 0);
+        if (FAILED(present)) {
+            std::printf("Present failed 0x%08lX after %d frames\n",
+                        static_cast<unsigned long>(present), presented);
+            break;
+        }
+        ++presented;
+    }
+    std::printf("presented %d frames, resizes %d, target clicks %d\n",
+                presented, resizes, g_target_clicks.load());
+
+    stop.request_stop();
+    if (platform.joinable()) platform.join();
+    static_cast<void>(plugins->StopForRuntime());
+    worker->Stop();
+    worker_stop.request_stop();
+    if (worker_thread.joinable()) worker_thread.join();
+    if (render_target != nullptr) render_target->Release();
+    swap_chain->Release();
+    context->Release();
+    device->Release();
+    DestroyWindow(window);
+    std::printf("ok\n");
+    return 0;
+}

--- a/src/render/dx12/embedded_bridge.cpp
+++ b/src/render/dx12/embedded_bridge.cpp
@@ -8,12 +8,39 @@
 
 #include <algorithm>
 #include <chrono>
+#include <cstring>
 #include <fstream>
 #include <functional>
+#include <iomanip>
+#include <sstream>
 #include <stop_token>
 #include <thread>
 
 namespace ue5mem::embedded {
+
+namespace {
+
+// Names a code address as module plus offset, for log lines that have to say
+// which component owns a byte range.
+std::string DescribeCodeAddress(void* address) {
+    if (address == nullptr) return "null";
+    HMODULE module{};
+    wchar_t path[MAX_PATH]{};
+    std::ostringstream text;
+    if (GetModuleHandleExW(
+            GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS | GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
+            static_cast<LPCWSTR>(static_cast<void*>(address)), &module) != 0 &&
+        GetModuleFileNameW(module, path, MAX_PATH) != 0) {
+        const std::filesystem::path leaf = std::filesystem::path(path).filename();
+        text << leaf.string() << "+0x" << std::hex
+             << (static_cast<unsigned char*>(address) - reinterpret_cast<unsigned char*>(module));
+        return text.str();
+    }
+    text << "0x" << std::hex << reinterpret_cast<std::uintptr_t>(address) << "(unmapped)";
+    return text.str();
+}
+
+}  // namespace
 
 std::atomic<EmbeddedState*> g_state{};
 PresentFn g_present{};
@@ -21,6 +48,9 @@ Present1Fn g_present1{};
 ResizeBuffersFn g_resize_buffers{};
 ResizeBuffers1Fn g_resize_buffers1{};
 ExecuteCommandListsFn g_execute_command_lists{};
+// Kept so a stalled start-up can report whether the detour installed here is
+// still the one in place. Internal linkage: nothing outside this file reads it.
+static void* g_execute_command_lists_target{};
 std::unique_ptr<anomaly::HookManager> g_hooks;
 std::atomic_bool g_performance_diagnostics_enabled{};
 
@@ -433,6 +463,7 @@ bool InstallHooks() {
     if (g_hooks != nullptr) return false;
     const HookTargets targets = DiscoverD3D12HookTargets();
     if (!targets) return false;
+    g_execute_command_lists_target = targets.execute_command_lists;
     g_hooks = std::make_unique<anomaly::HookManager>(anomaly::CreateMinHookBackend());
     return g_hooks->Create(
                std::string(kRendererHookOwner), kRendererHookGeneration, "execute-command-lists",
@@ -490,10 +521,36 @@ bool InstallHooks() {
     g_resize_buffers = nullptr;
     g_resize_buffers1 = nullptr;
     g_execute_command_lists = nullptr;
+    g_execute_command_lists_target = nullptr;
     return true;
 }
 
 }  // namespace
+
+std::string DescribeEmbeddedSubmissionTarget() {
+    void* const target = g_execute_command_lists_target;
+    if (target == nullptr) return "target=none";
+    std::ostringstream description;
+    const auto* bytes = static_cast<const unsigned char*>(target);
+    description << "target=" << DescribeCodeAddress(target) << " bytes=";
+    for (int index = 0; index < 5; ++index) {
+        description << std::hex << std::setw(2) << std::setfill('0')
+                    << static_cast<unsigned>(bytes[index]);
+    }
+    description << std::dec;
+    // A five byte relative jump is what every trampoline hook on x64 leaves
+    // behind. Naming the module it lands in separates "our detour is in effect"
+    // from "something else overwrote it", which the call counters alone cannot.
+    if (bytes[0] == 0xE9) {
+        std::int32_t displacement{};
+        std::memcpy(&displacement, bytes + 1, sizeof(displacement));
+        void* const destination = const_cast<unsigned char*>(bytes) + 5 + displacement;
+        description << " jumpsTo=" << DescribeCodeAddress(destination);
+    } else {
+        description << " notAJump";
+    }
+    return description.str();
+}
 
 }  // namespace ue5mem::embedded
 

--- a/src/render/dx12/embedded_host_internal.hpp
+++ b/src/render/dx12/embedded_host_internal.hpp
@@ -10,6 +10,7 @@
 #include "plugin_manager.hpp"
 
 #include <Windows.h>
+#include <d3d11.h>
 #include <d3d12.h>
 #include <dxgi1_4.h>
 
@@ -193,6 +194,13 @@ enum class RendererLifecycle : std::uint8_t {
     Stopped,
 };
 
+// Which Direct3D version the intercepted swap chain belongs to.
+//
+// The Present hook lives in DXGI, which every Direct3D version shares, so the
+// overlay gets called for a D3D11 title exactly as it does for a D3D12 one and
+// has to draw with whichever API the back buffer actually belongs to.
+enum class EmbeddedRenderApi : std::uint8_t { None, D3D12, D3D11 };
+
 struct HookTargets {
     void* execute_command_lists{};
     void* present{};
@@ -205,6 +213,11 @@ struct HookTargets {
             present1 != nullptr && resize_buffers != nullptr && resize_buffers1 != nullptr;
     }
 };
+
+// Reports what the submission target's first bytes currently look like and,
+// when they are a jump, which module it lands in. Distinguishes a detour that
+// is still ours from one that was overwritten by another hook.
+[[nodiscard]] std::string DescribeEmbeddedSubmissionTarget();
 
 struct EmbeddedState {
     std::filesystem::path root;
@@ -238,6 +251,15 @@ struct EmbeddedState {
     ID3D12Fence* fence{};
     HANDLE fence_event{};
     std::vector<FrameContext> frames;
+    // Set once the swap chain's API is known, and the switch every per-frame
+    // path branches on. D3D11 needs none of the queue, fence, allocator or
+    // descriptor-heap machinery above it: the immediate context is the whole
+    // submission model.
+    EmbeddedRenderApi render_api{EmbeddedRenderApi::None};
+    ID3D11Device* d3d11_device{};
+    ID3D11DeviceContext* d3d11_context{};
+    ID3D11RenderTargetView* d3d11_render_target{};
+    bool dx11_initialized{};
     DXGI_FORMAT render_target_format{DXGI_FORMAT_UNKNOWN};
     UINT64 next_fence_value{1};
     bool submission_unfenced{};
@@ -245,6 +267,18 @@ struct EmbeddedState {
     HWND window{};
     ImGuiContext* imgui_context{};
     WNDPROC original_window_proc{};
+    // Set when the window procedure could not be exchanged. The overlay still
+    // renders in that case, so the reason has to survive for diagnostics.
+    unsigned long input_install_error{};
+    bool input_installed{};
+    // Evidence about the command-queue handover, which only a D3D12 title
+    // performs. The overlay submits onto the game's own direct queue so its
+    // draws stay ordered against the game's frame, which means a missing queue
+    // stops the overlay entirely. These counters separate "the submission hook
+    // never fires" from "it fires but never with a direct queue" in a log.
+    std::atomic<std::uint64_t> execute_hook_calls{};
+    std::atomic<std::uint64_t> execute_direct_queues{};
+    std::atomic<std::uint32_t> observed_queue_types{};
     HWND previous_capture{};
     RECT previous_cursor_clip{};
     bool cursor_clip_saved{};

--- a/src/render/dx12/embedded_input.cpp
+++ b/src/render/dx12/embedded_input.cpp
@@ -490,12 +490,37 @@ void PublishEmbeddedUiCapture(EmbeddedState& state) noexcept {
 }
 
 bool InstallEmbeddedInput(EmbeddedState& state) noexcept {
+    state.input_installed = false;
+    state.input_install_error = ERROR_SUCCESS;
+    if (state.window == nullptr || !IsWindow(state.window)) {
+        state.input_install_error = ERROR_INVALID_WINDOW_HANDLE;
+        return false;
+    }
     SetLastError(ERROR_SUCCESS);
     const LONG_PTR previous = SetWindowLongPtrW(
         state.window, GWLP_WNDPROC, reinterpret_cast<LONG_PTR>(EmbeddedWindowProc));
-    if (previous == 0 && GetLastError() != ERROR_SUCCESS) return false;
+    if (previous == 0) {
+        const DWORD error = GetLastError();
+        state.input_install_error = error == ERROR_SUCCESS ? ERROR_NOT_SUPPORTED : error;
+        if (error != ERROR_SUCCESS) {
+            // The exchange was refused, so the game still owns its procedure and
+            // there is nothing to undo.
+            return false;
+        }
+        // The exchange went through but produced no forwarding target. Leaving
+        // this procedure installed would route every game message to
+        // DefWindowProc and the window would stop responding, so put the
+        // window back the only way still available and report the failure.
+        if (GetWindowLongPtrW(state.window, GWLP_WNDPROC) ==
+            reinterpret_cast<LONG_PTR>(EmbeddedWindowProc)) {
+            SetLastError(ERROR_SUCCESS);
+            static_cast<void>(SetWindowLongPtrW(state.window, GWLP_WNDPROC, previous));
+        }
+        return false;
+    }
     state.original_window_proc = reinterpret_cast<WNDPROC>(previous);
-    return state.original_window_proc != nullptr;
+    state.input_installed = true;
+    return true;
 }
 
 void RestoreEmbeddedInput(EmbeddedState& state) noexcept {
@@ -504,6 +529,7 @@ void RestoreEmbeddedInput(EmbeddedState& state) noexcept {
         ClearInputMailbox(state.input_mailbox, anomaly::InputResetReason::FocusLost);
     } catch (...) {
     }
+    state.input_installed = false;
     if (state.original_window_proc == nullptr || !IsWindow(state.window)) {
         state.original_window_proc = nullptr;
         return;

--- a/src/render/dx12/embedded_renderer.cpp
+++ b/src/render/dx12/embedded_renderer.cpp
@@ -7,17 +7,91 @@
 #include "embedded_ui_resource_render_backend.hpp"
 
 #include <imgui.h>
+#include <backends/imgui_impl_dx11.h>
 #include <backends/imgui_impl_dx12.h>
 #include <backends/imgui_impl_win32.h>
 
+#include <array>
 #include <cstring>
+#include <fstream>
 #include <functional>
 #include <limits>
+#include <mutex>
+#include <set>
 #include <sstream>
 #include <utility>
 
 namespace ue5mem::embedded {
 namespace {
+
+// Says why the overlay is not on screen.
+//
+// Embedded start-up used to be entirely silent: a dozen separate conditions
+// could each abandon the frame with a bare `return`, so a user whose overlay
+// never appeared had nothing to go on and neither did anyone reading a bug
+// report. Every abandoned start-up now names its reason exactly once per
+// reason, which keeps a per-frame path from turning into a log flood while
+// still surfacing the first cause and any later change of cause.
+void ReportEmbeddedGate(
+        const EmbeddedState& state, const char* reason, const std::string& detail = {},
+        const char* prefix = "embedded overlay not started: ") noexcept {
+    try {
+        static std::mutex mutex;
+        static std::set<std::string> reported;
+        const std::string key = std::string(reason) + '|' + detail;
+        {
+            std::scoped_lock lock(mutex);
+            if (!reported.insert(key).second) return;
+        }
+        std::string message = std::string(prefix) + reason;
+        if (!detail.empty()) message += " (" + detail + ")";
+        std::ofstream(state.root / L"anomaly-platform.log", std::ios::app)
+            << "pid=" << GetCurrentProcessId() << ' ' << message << std::endl;
+        if (state.diagnostics.logger != nullptr) {
+            anomaly::LogDetails details;
+            details.thread_domain = anomaly::LogThreadDomain::Render;
+            details.event_id = "embedded.gate";
+            static_cast<void>(state.diagnostics.logger->Log(
+                anomaly::LogLevel::Warning, "embedded-renderer", message, std::move(details)));
+        }
+    } catch (...) {
+    }
+}
+
+// Drives the overlay from polled device state.
+//
+// Used only when the game window's procedure could not be exchanged. ImGui
+// normally learns about input from window messages, so without that hook the
+// overlay would draw but ignore the mouse entirely, which is barely better than
+// not drawing at all. Polling is coarser -- no character input, no scroll
+// accumulation between frames -- but it restores pointing and clicking, which is
+// what the panels actually need.
+void FeedPolledInput(const EmbeddedState& state) noexcept {
+    if (state.window == nullptr) return;
+    ImGuiIO& io = ImGui::GetIO();
+    POINT cursor{};
+    if (GetCursorPos(&cursor) && ScreenToClient(state.window, &cursor)) {
+        io.AddMousePosEvent(static_cast<float>(cursor.x), static_cast<float>(cursor.y));
+    }
+    const bool foreground = GetForegroundWindow() == state.window;
+    io.AddFocusEvent(foreground);
+    if (!foreground) return;
+    struct PolledButton {
+        int virtual_key;
+        int imgui_button;
+    };
+    static constexpr std::array<PolledButton, 3> buttons{{
+        {VK_LBUTTON, 0}, {VK_RBUTTON, 1}, {VK_MBUTTON, 2}}};
+    for (const PolledButton& button : buttons) {
+        const bool down = (GetAsyncKeyState(button.virtual_key) & 0x8000) != 0;
+        io.AddMouseButtonEvent(button.imgui_button, down);
+    }
+}
+
+std::string LastErrorDetail(const char* label, unsigned long error) {
+    return std::string(label) + "=" + std::to_string(error);
+}
+
 
 class PerformanceTimer final {
 public:
@@ -346,6 +420,9 @@ void CopyBackBuffer(
 }
 
 bool ReleaseBackBuffersForResize(EmbeddedState& state) {
+    // ResizeBuffers fails while anything still references a back buffer, and on
+    // D3D11 the overlay's render target view is that reference.
+    Release(state.d3d11_render_target);
     const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(5);
     for (auto& frame : state.frames) {
         const auto now = std::chrono::steady_clock::now();
@@ -531,6 +608,29 @@ bool ReconfigureFramesAfterResize(
 
 bool RebuildBackBuffersAfterResize(
     EmbeddedState& state, bool force_renderer_reconfigure = false) {
+    if (state.render_api == EmbeddedRenderApi::D3D11) {
+        // Only the render target view needs rebuilding; there is no descriptor
+        // heap and no per-frame context to reconfigure.
+        if (state.source_swap_chain == nullptr || state.d3d11_device == nullptr) return false;
+        ID3D11Texture2D* back_buffer{};
+        if (FAILED(state.source_swap_chain->GetBuffer(0, IID_PPV_ARGS(&back_buffer))) ||
+            back_buffer == nullptr) {
+            Release(back_buffer);
+            return false;
+        }
+        const HRESULT created = state.d3d11_device->CreateRenderTargetView(
+            back_buffer, nullptr, &state.d3d11_render_target);
+        Release(back_buffer);
+        if (FAILED(created) || state.d3d11_render_target == nullptr) return false;
+        RECT output_rect{};
+        if (state.window != nullptr && GetClientRect(state.window, &output_rect)) {
+            const LONG width = (std::max)(0L, output_rect.right - output_rect.left);
+            const LONG height = (std::max)(0L, output_rect.bottom - output_rect.top);
+            state.selected_area =
+                static_cast<std::uint64_t>(width) * static_cast<std::uint64_t>(height);
+        }
+        return true;
+    }
     if (state.source_swap_chain == nullptr || state.device == nullptr ||
         state.render_target_heap == nullptr) return false;
     DXGI_SWAP_CHAIN_DESC description{};
@@ -616,11 +716,49 @@ bool PreferSwapChain(const EmbeddedState& state, IDXGISwapChain* candidate) {
     return candidate_area > state.selected_area + state.selected_area / 4;
 }
 
-bool InitializeGraphics(EmbeddedState& state, IDXGISwapChain* swap_chain) {
+// Names the graphics API behind a swap chain.
+//
+// The Present hook lives in DXGI, which every Direct3D version shares, so it
+// fires for a D3D11 swap chain exactly as it does for a D3D12 one. Everything
+// downstream of it here is D3D12 only. When the device query fails there is no
+// way to tell "wrong API" from "device query failed" without asking, so ask.
+std::string DescribeSwapChainApi(IDXGISwapChain* swap_chain) {
+    if (swap_chain == nullptr) return "swapChain=null";
+    std::string description = "api=";
+    void* probe{};
+    const auto query = [&](const IID& id) {
+        probe = nullptr;
+        return SUCCEEDED(swap_chain->GetDevice(id, &probe)) && probe != nullptr;
+    };
+    if (query(__uuidof(ID3D12Device))) {
+        description += "d3d12";
+    } else if (query(IID{0xdb6f6ddb, 0xac77, 0x4e88, {0x82, 0x53, 0x81, 0x9d, 0xf9, 0xbb, 0xf1, 0x40}})) {
+        // ID3D11Device, spelled out so this file does not have to pull in d3d11.h.
+        description += "d3d11";
+    } else if (query(IID{0x9b7e4c0f, 0x342c, 0x4106, {0xa1, 0x9f, 0x4f, 0x27, 0x04, 0xf6, 0x89, 0xf0}})) {
+        // ID3D10Device1.
+        description += "d3d10";
+    } else {
+        description += "unknown";
+    }
+    if (probe != nullptr) static_cast<IUnknown*>(probe)->Release();
+    DXGI_SWAP_CHAIN_DESC layout{};
+    if (SUCCEEDED(swap_chain->GetDesc(&layout))) {
+        description += " buffers=" + std::to_string(layout.BufferCount) +
+            " format=" + std::to_string(static_cast<int>(layout.BufferDesc.Format)) +
+            " windowed=" + std::to_string(layout.Windowed ? 1 : 0);
+    }
+    return description;
+}
+
+bool CompleteGraphicsInitialization(EmbeddedState& state);
+
+bool InitializeGraphicsD3D12(EmbeddedState& state, IDXGISwapChain* swap_chain) {
     if (state.plugins == nullptr || state.quarantined_plugin_owner != nullptr ||
         PlatformUiQuarantined(state.plugins)) {
         // A retained owner is a generation fence. Do not allocate another
         // ImGui/device generation until the prior UI callbacks have drained.
+        ReportEmbeddedGate(state, "plugin host unavailable or quarantined");
         return false;
     }
     // A previous device generation may have stopped accepting UI work but
@@ -638,6 +776,29 @@ bool InitializeGraphics(EmbeddedState& state, IDXGISwapChain* swap_chain) {
         if (queue != nullptr) queue->AddRef();
     }
     if (queue == nullptr) {
+        // Normal for the first frames, permanent if the submission hook never
+        // delivers. Repeat with the live evidence so the two cases can be told
+        // apart: the counters say whether the hook ran at all, the target
+        // description says whether the detour is still the one installed here,
+        // and the swap chain description says which API it belongs to.
+        static std::atomic<long long> next_report{};
+        const auto now = std::chrono::steady_clock::now().time_since_epoch().count();
+        long long expected = next_report.load(std::memory_order_relaxed);
+        if (now >= expected &&
+            next_report.compare_exchange_strong(
+                expected, now + std::chrono::steady_clock::duration(
+                    std::chrono::seconds(5)).count())) {
+            std::ostringstream detail;
+            detail << "submissionHookCalls="
+                   << state.execute_hook_calls.load(std::memory_order_relaxed)
+                   << " directQueues="
+                   << state.execute_direct_queues.load(std::memory_order_relaxed)
+                   << " queueTypeMask=0x" << std::hex
+                   << state.observed_queue_types.load(std::memory_order_relaxed) << std::dec
+                   << ' ' << DescribeEmbeddedSubmissionTarget()
+                   << ' ' << DescribeSwapChainApi(swap_chain);
+            ReportEmbeddedGate(state, "no direct command queue captured yet", detail.str());
+        }
         state.renderer = RendererLifecycle::Cold;
         return false;
     }
@@ -649,6 +810,9 @@ bool InitializeGraphics(EmbeddedState& state, IDXGISwapChain* swap_chain) {
         FAILED(swap_chain->GetDevice(IID_PPV_ARGS(&device))) ||
         FAILED(swap_chain->GetDesc(&description)) || description.BufferCount == 0 ||
         description.OutputWindow == nullptr) {
+        ReportEmbeddedGate(
+            state, "swap chain is not a usable D3D12 target "
+            "(no IDXGISwapChain3, no ID3D12Device, or no output window)");
         Release(queue);
         Release(device);
         Release(swap_chain3);
@@ -663,6 +827,11 @@ bool InitializeGraphics(EmbeddedState& state, IDXGISwapChain* swap_chain) {
     const LONG height = output_rect.bottom - output_rect.top;
     if (output_process != GetCurrentProcessId() || !IsWindowVisible(description.OutputWindow) ||
         width < 640 || height < 360) {
+        ReportEmbeddedGate(
+            state, "output window rejected",
+            "process=" + std::to_string(output_process) +
+                " visible=" + std::to_string(IsWindowVisible(description.OutputWindow) ? 1 : 0) +
+                " size=" + std::to_string(width) + "x" + std::to_string(height));
         Release(queue);
         Release(device);
         Release(swap_chain3);
@@ -782,9 +951,23 @@ bool InitializeGraphics(EmbeddedState& state, IDXGISwapChain* swap_chain) {
     state.render_queue = queue;
     state.render_target_format = description.BufferDesc.Format;
     state.dx12_initialized = true;
+    state.render_api = EmbeddedRenderApi::D3D12;
+    return CompleteGraphicsInitialization(state);
+}
+
+// Everything after the device objects exist, which is identical whichever
+// Direct3D version owns the back buffer. The resource backend serves both, so
+// plugin fonts and icons work the same way on each.
+bool CompleteGraphicsInitialization(EmbeddedState& state) {
     if (!InstallEmbeddedInput(state)) {
-        static_cast<void>(ReleaseGraphics(state, RendererLifecycle::DeviceLost));
-        return false;
+        // Losing the window procedure costs interactivity, not the overlay.
+        // Tearing the renderer down here is what turned a recoverable input
+        // problem into a completely dead platform: no UI service reaches the
+        // plugins, so nothing renders and the hotkey never runs either.
+        ReportEmbeddedGate(
+            state, "window procedure could not be hooked; overlay stays visible but "
+            "will not accept mouse or keyboard",
+            LastErrorDetail("error", state.input_install_error));
     }
     {
         std::scoped_lock plugin_lock(*state.plugin_mutex);
@@ -875,7 +1058,134 @@ bool InitializeGraphics(EmbeddedState& state, IDXGISwapChain* swap_chain) {
         static_cast<void>(state.diagnostics.logger->Log(
             anomaly::LogLevel::Info, "render", message.str(), std::move(details)));
     }
+    // Also written to the plain platform log, which is where every abandoned
+    // start-up above reports, so a successful one is visible in the same place.
+    {
+        std::ostringstream ready;
+        ready << "api=" << (state.render_api == EmbeddedRenderApi::D3D11 ? "d3d11" : "d3d12")
+              << " hwnd=0x" << std::hex << reinterpret_cast<std::uintptr_t>(state.window)
+              << std::dec << " toggleKey=" << state.config.platform_toggle_key
+              << " inputHooked=" << (state.input_installed ? 1 : 0);
+        ReportEmbeddedGate(state, "ready", ready.str(), "embedded overlay: ");
+    }
     return true;
+}
+
+// Binds a render target view to back buffer zero.
+//
+// Split out because the view has to be dropped before ResizeBuffers and rebuilt
+// afterwards; holding a reference to a back buffer is what makes a resize fail.
+bool CreateD3D11RenderTarget(EmbeddedState& state) {
+    if (state.d3d11_device == nullptr || state.source_swap_chain == nullptr) return false;
+    ID3D11Texture2D* back_buffer{};
+    if (FAILED(state.source_swap_chain->GetBuffer(0, IID_PPV_ARGS(&back_buffer))) ||
+        back_buffer == nullptr) {
+        Release(back_buffer);
+        return false;
+    }
+    const HRESULT created = state.d3d11_device->CreateRenderTargetView(
+        back_buffer, nullptr, &state.d3d11_render_target);
+    Release(back_buffer);
+    return SUCCEEDED(created) && state.d3d11_render_target != nullptr;
+}
+
+void ReleaseD3D11RenderTarget(EmbeddedState& state) noexcept {
+    Release(state.d3d11_render_target);
+}
+
+// Brings the overlay up on a swap chain owned by a D3D11 device.
+//
+// Far smaller than the D3D12 path because the immediate context is the entire
+// submission model: no command queue to capture, no allocators, no fences, no
+// resource barriers, and one render target view instead of a descriptor heap.
+bool InitializeGraphicsD3D11(EmbeddedState& state, IDXGISwapChain* swap_chain) {
+    if (state.plugins == nullptr || state.quarantined_plugin_owner != nullptr ||
+        PlatformUiQuarantined(state.plugins)) {
+        ReportEmbeddedGate(state, "plugin host unavailable or quarantined");
+        return false;
+    }
+    if (state.platform_ui_initialized &&
+        !ReleaseGraphics(state, RendererLifecycle::Cold)) {
+        return false;
+    }
+    state.renderer = RendererLifecycle::Discovering;
+    ID3D11Device* device{};
+    DXGI_SWAP_CHAIN_DESC description{};
+    if (FAILED(swap_chain->GetDevice(IID_PPV_ARGS(&device))) || device == nullptr ||
+        FAILED(swap_chain->GetDesc(&description)) || description.BufferCount == 0 ||
+        description.OutputWindow == nullptr) {
+        Release(device);
+        ReportEmbeddedGate(
+            state, "swap chain is not a usable D3D11 target",
+            DescribeSwapChainApi(swap_chain));
+        state.renderer = RendererLifecycle::Cold;
+        return false;
+    }
+    DWORD output_process{};
+    GetWindowThreadProcessId(description.OutputWindow, &output_process);
+    RECT output_rect{};
+    GetClientRect(description.OutputWindow, &output_rect);
+    const LONG width = output_rect.right - output_rect.left;
+    const LONG height = output_rect.bottom - output_rect.top;
+    if (output_process != GetCurrentProcessId() || !IsWindowVisible(description.OutputWindow) ||
+        width < 640 || height < 360) {
+        Release(device);
+        ReportEmbeddedGate(
+            state, "output window rejected",
+            "process=" + std::to_string(output_process) +
+                " visible=" + std::to_string(IsWindowVisible(description.OutputWindow) ? 1 : 0) +
+                " size=" + std::to_string(width) + "x" + std::to_string(height));
+        state.renderer = RendererLifecycle::Cold;
+        return false;
+    }
+    state.d3d11_device = device;
+    device->GetImmediateContext(&state.d3d11_context);
+    swap_chain->AddRef();
+    state.source_swap_chain = swap_chain;
+    state.window = description.OutputWindow;
+    state.render_target_format = description.BufferDesc.Format;
+    state.selected_area = static_cast<std::uint64_t>(width) * static_cast<std::uint64_t>(height);
+    if (state.d3d11_context == nullptr || !CreateD3D11RenderTarget(state)) {
+        ReportEmbeddedGate(state, "could not bind a render target to the D3D11 back buffer");
+        static_cast<void>(ReleaseGraphics(state, RendererLifecycle::DeviceLost));
+        return false;
+    }
+    IMGUI_CHECKVERSION();
+    state.imgui_context = ImGui::CreateContext();
+    if (state.imgui_context == nullptr) {
+        static_cast<void>(ReleaseGraphics(state, RendererLifecycle::DeviceLost));
+        return false;
+    }
+    static_cast<void>(ConfigurePlatformUiFontAtlas(state.root));
+    ImGuiIO& io = ImGui::GetIO();
+    io.ConfigFlags |= ImGuiConfigFlags_NavEnableKeyboard | ImGuiConfigFlags_NoMouseCursorChange;
+    state.imgui_ini_path = (state.root / L"anomaly-imgui.ini").string();
+    io.IniFilename = state.imgui_ini_path.c_str();
+    if (!ImGui_ImplWin32_Init(state.window)) {
+        static_cast<void>(ReleaseGraphics(state, RendererLifecycle::DeviceLost));
+        return false;
+    }
+    state.win32_initialized = true;
+    if (!ImGui_ImplDX11_Init(state.d3d11_device, state.d3d11_context)) {
+        static_cast<void>(ReleaseGraphics(state, RendererLifecycle::DeviceLost));
+        return false;
+    }
+    state.dx11_initialized = true;
+    state.render_api = EmbeddedRenderApi::D3D11;
+    return CompleteGraphicsInitialization(state);
+}
+
+bool InitializeGraphics(EmbeddedState& state, IDXGISwapChain* swap_chain) {
+    if (swap_chain == nullptr) return false;
+    // Asking the swap chain settles which API owns the back buffer. Guessing
+    // wrong here is what left the overlay waiting forever for a command queue
+    // that a D3D11 title never creates.
+    ID3D12Device* probe{};
+    const bool is_d3d12 =
+        SUCCEEDED(swap_chain->GetDevice(IID_PPV_ARGS(&probe))) && probe != nullptr;
+    Release(probe);
+    return is_d3d12 ? InitializeGraphicsD3D12(state, swap_chain)
+                    : InitializeGraphicsD3D11(state, swap_chain);
 }
 
 }  // namespace
@@ -964,6 +1274,10 @@ bool ReleaseGraphics(
         ImGui_ImplDX12_Shutdown();
         state.dx12_initialized = false;
     }
+    if (state.dx11_initialized) {
+        ImGui_ImplDX11_Shutdown();
+        state.dx11_initialized = false;
+    }
     state.shader_descriptors.Reset();
     if (state.win32_initialized) {
         ImGui_ImplWin32_Shutdown();
@@ -987,6 +1301,10 @@ bool ReleaseGraphics(
     Release(state.shader_heap);
     Release(state.render_target_heap);
     Release(state.device);
+    ReleaseD3D11RenderTarget(state);
+    Release(state.d3d11_context);
+    Release(state.d3d11_device);
+    state.render_api = EmbeddedRenderApi::None;
     ClearPendingResizeQueue(state);
     Release(state.render_queue);
     Release(state.swap_chain);
@@ -1036,36 +1354,58 @@ void RenderEmbedded(IDXGISwapChain* swap_chain, UINT flags) {
     const int toggle_state = GetAsyncKeyState(static_cast<int>(toggle_key));
     if (anomaly::ShouldTogglePlatformMenus(
             PlatformUiCapturingHotkey(), toggle_state)) {
-        anomaly::SetHostUiMenusCollapsed(!anomaly::HostUiMenusCollapsed());
+        const bool expanding = anomaly::HostUiMenusCollapsed();
+        anomaly::SetHostUiMenusCollapsed(!expanding);
+        // The shell's own close button marks the management window closed, and
+        // that state is persisted. Collapsing is not the same as closing, so a
+        // hotkey that only flipped the collapse flag could never bring a closed
+        // shell back -- not in that session and not in any later one, because
+        // start-up reads the persisted state and collapses again. Reopening here
+        // is what makes the hotkey a way back in.
+        if (expanding) static_cast<void>(RevealPlatformUi());
     }
     static_cast<void>(ApplyHostUiManagementExpansionRequest());
 
-    const UINT index = state->swap_chain->GetCurrentBackBufferIndex();
-    if (index >= state->frames.size()) return;
-    auto& frame = state->frames[index];
-    const std::uint64_t capture_generation = CaptureGeneration(*state);
-    SynchronizeSmokeProbeCapture(state->pixel_probe.policy, capture_generation);
-    static_cast<void>(CompletePixelProbe(*state, capture_generation));
-    setup_timer.Stop();
-    PerformanceTimer fence_timer(
-        state->performance, EmbeddedPerformanceStage::RenderFenceWait, sampled);
-    const bool frame_ready = WaitForFrame(*state, frame);
-    fence_timer.Stop();
-    if (!frame_ready) return;
-    PerformanceTimer reset_timer(
-        state->performance, EmbeddedPerformanceStage::RenderFrameReset, sampled);
-    if (FAILED(frame.allocator->Reset()) ||
-        FAILED(state->command_list->Reset(frame.allocator, nullptr))) {
-        static_cast<void>(ReleaseGraphics(*state, RendererLifecycle::DeviceLost));
-        return;
+    // D3D11 submits through the immediate context, so none of the back buffer
+    // index, fence wait, allocator reset or pixel probe below applies to it.
+    const bool immediate_mode = state->render_api == EmbeddedRenderApi::D3D11;
+    FrameContext* frame_context{};
+    std::uint64_t capture_generation{};
+    bool probing = false;
+    if (immediate_mode) {
+        setup_timer.Stop();
+    } else {
+        const UINT index = state->swap_chain->GetCurrentBackBufferIndex();
+        if (index >= state->frames.size()) return;
+        frame_context = &state->frames[index];
+        capture_generation = CaptureGeneration(*state);
+        SynchronizeSmokeProbeCapture(state->pixel_probe.policy, capture_generation);
+        static_cast<void>(CompletePixelProbe(*state, capture_generation));
+        setup_timer.Stop();
+        PerformanceTimer fence_timer(
+            state->performance, EmbeddedPerformanceStage::RenderFenceWait, sampled);
+        const bool frame_ready = WaitForFrame(*state, *frame_context);
+        fence_timer.Stop();
+        if (!frame_ready) return;
+        PerformanceTimer reset_timer(
+            state->performance, EmbeddedPerformanceStage::RenderFrameReset, sampled);
+        if (FAILED(frame_context->allocator->Reset()) ||
+            FAILED(state->command_list->Reset(frame_context->allocator, nullptr))) {
+            static_cast<void>(ReleaseGraphics(*state, RendererLifecycle::DeviceLost));
+            return;
+        }
+        probing = capture_generation != 0 &&
+            PreparePixelProbe(*state, *frame_context, capture_generation);
+        reset_timer.Stop();
     }
-    const bool probing = capture_generation != 0 &&
-        PreparePixelProbe(*state, frame, capture_generation);
-    reset_timer.Stop();
 
     PerformanceTimer ui_timer(
         state->performance, EmbeddedPerformanceStage::RenderUi, sampled);
-    ImGui_ImplDX12_NewFrame();
+    if (immediate_mode) {
+        ImGui_ImplDX11_NewFrame();
+    } else {
+        ImGui_ImplDX12_NewFrame();
+    }
     // NewFrame creates the ImGui font atlas first, reserving descriptor slot
     // zero before scoped texture uploads allocate from the shared heap.
     const auto prepare_lock_started = sampled ? std::chrono::steady_clock::now()
@@ -1092,6 +1432,7 @@ void RenderEmbedded(IDXGISwapChain* swap_chain, UINT flags) {
                                              : std::chrono::steady_clock::time_point{};
     UpdateMenuCursor(*state, anomaly::HostUiMenusCaptureMouse());
     ImGui_ImplWin32_NewFrame();
+    if (!state->input_installed) FeedPolledInput(*state);
     ImGui::NewFrame();
     anomaly::PrepareHostUiFrame();
     if (sampled) {
@@ -1165,9 +1506,37 @@ void RenderEmbedded(IDXGISwapChain* swap_chain, UINT flags) {
     }
     ui_timer.Stop();
 
-    PerformanceTimer command_timer(
-        state->performance, EmbeddedPerformanceStage::RenderCommands, sampled);
-    if (probing) {
+    if (immediate_mode) {
+        PerformanceTimer command_timer(
+            state->performance, EmbeddedPerformanceStage::RenderCommands, sampled);
+        if (state->d3d11_context == nullptr || state->d3d11_render_target == nullptr) {
+            static_cast<void>(ReleaseGraphics(*state, RendererLifecycle::DeviceLost));
+            return;
+        }
+        // The game leaves its own targets bound. Binding the back buffer for the
+        // overlay draw and nothing else is the whole of the D3D11 submission:
+        // the immediate context is already ordered behind the game's work.
+        //
+        // ImGui's D3D11 backend restores whatever was bound when it was entered,
+        // which by then is the overlay's own target, so the game's binding has
+        // to be saved and put back here instead.
+        ID3D11RenderTargetView* previous_targets[D3D11_SIMULTANEOUS_RENDER_TARGET_COUNT]{};
+        ID3D11DepthStencilView* previous_depth{};
+        state->d3d11_context->OMGetRenderTargets(
+            D3D11_SIMULTANEOUS_RENDER_TARGET_COUNT, previous_targets, &previous_depth);
+        ID3D11RenderTargetView* targets[]{state->d3d11_render_target};
+        state->d3d11_context->OMSetRenderTargets(1, targets, nullptr);
+        ImGui_ImplDX11_RenderDrawData(ImGui::GetDrawData());
+        state->d3d11_context->OMSetRenderTargets(
+            D3D11_SIMULTANEOUS_RENDER_TARGET_COUNT, previous_targets, previous_depth);
+        for (auto* previous : previous_targets) Release(previous);
+        Release(previous_depth);
+        command_timer.Stop();
+    } else {
+        auto& frame = *frame_context;
+        PerformanceTimer command_timer(
+            state->performance, EmbeddedPerformanceStage::RenderCommands, sampled);
+        if (probing) {
         auto to_copy = Transition(
             frame.back_buffer, D3D12_RESOURCE_STATE_PRESENT,
             D3D12_RESOURCE_STATE_COPY_SOURCE);
@@ -1236,6 +1605,7 @@ void RenderEmbedded(IDXGISwapChain* swap_chain, UINT flags) {
         return;
     }
     submit_timer.Stop();
+    }
     }
     // Lifecycle mutations are submitted only after the render mutex and the
     // plugin draw lock have been released, so a slow reload cannot block
@@ -1320,8 +1690,16 @@ void FinishResizeEvidenceHandoff(bool successful) noexcept {
 
 void CaptureCommandQueue(ID3D12CommandQueue* queue) {
     auto* state = g_state.load(std::memory_order_acquire);
-    if (state == nullptr || queue == nullptr ||
-        queue->GetDesc().Type != D3D12_COMMAND_LIST_TYPE_DIRECT) return;
+    if (state == nullptr) return;
+    state->execute_hook_calls.fetch_add(1, std::memory_order_relaxed);
+    if (queue == nullptr) return;
+    const D3D12_COMMAND_LIST_TYPE type = queue->GetDesc().Type;
+    if (type >= 0 && type < 31) {
+        state->observed_queue_types.fetch_or(
+            1u << static_cast<unsigned>(type), std::memory_order_relaxed);
+    }
+    if (type != D3D12_COMMAND_LIST_TYPE_DIRECT) return;
+    state->execute_direct_queues.fetch_add(1, std::memory_order_relaxed);
     std::scoped_lock lock(state->queue_mutex);
     if (state->captured_queue == queue) return;
     queue->AddRef();

--- a/src/render/dx12/embedded_ui_resource_render_backend.cpp
+++ b/src/render/dx12/embedded_ui_resource_render_backend.cpp
@@ -6,6 +6,7 @@
 #include "anomaly/ui_resource_render_backend.hpp"
 
 #include <imgui.h>
+#include <backends/imgui_impl_dx11.h>
 #include <backends/imgui_impl_dx12.h>
 
 #include <wrl/client.h>
@@ -32,10 +33,16 @@ constexpr std::uint64_t kUiTextureCacheBudgetBytes = 128ULL * 1024ULL * 1024ULL;
 
 // Texture cache admission accounts for the logical RGBA texture and the
 // temporary row-pitch-padded upload resource. The latter is returned once its
-// copy submission fence completes.
+// copy submission fence completes. D3D11 has no such staging resource: the
+// pixels are handed to CreateTexture2D directly, so it accounts for nothing.
 [[nodiscard]] bool EstimateTextureUploadBytes(
-    const anomaly::UiTextureRequest& request, std::uint64_t* upload_bytes) noexcept {
+    const anomaly::UiTextureRequest& request, std::uint64_t* upload_bytes,
+    const bool immediate_upload) noexcept {
     if (upload_bytes == nullptr || request.width == 0 || request.height == 0) return false;
+    if (immediate_upload) {
+        *upload_bytes = 0;
+        return true;
+    }
     constexpr std::uint64_t pitch_alignment = D3D12_TEXTURE_DATA_PITCH_ALIGNMENT;
     constexpr std::uint64_t placement_alignment = D3D12_TEXTURE_DATA_PLACEMENT_ALIGNMENT;
     const std::uint64_t row_bytes = static_cast<std::uint64_t>(request.width) * 4U;
@@ -81,6 +88,17 @@ struct TextureEntry final {
     std::vector<LeaseReference> leases;
     Microsoft::WRL::ComPtr<ID3D12Resource> texture;
     Microsoft::WRL::ComPtr<ID3D12Resource> upload;
+    // D3D11 keeps the texture and its view instead; the view pointer is what
+    // ImGui draws with, standing in for the D3D12 descriptor below.
+    Microsoft::WRL::ComPtr<ID3D11Texture2D> d3d11_texture;
+    Microsoft::WRL::ComPtr<ID3D11ShaderResourceView> d3d11_view;
+
+    // Whether this entry already holds something drawable. Which member proves
+    // that differs by API, and testing the wrong one silently turns the
+    // "already uploaded" check into a miss, re-uploading every single frame.
+    [[nodiscard]] bool Resident(const bool immediate) const noexcept {
+        return immediate ? d3d11_view != nullptr : gpu.ptr != 0;
+    }
     D3D12_CPU_DESCRIPTOR_HANDLE cpu{};
     D3D12_GPU_DESCRIPTOR_HANDLE gpu{};
     std::uint64_t byte_size{};
@@ -159,7 +177,12 @@ public:
                 return false;
             }
             const auto found = textures_.find(resource->resource_id);
-            if (found == textures_.end() || found->second.gpu.ptr == 0 ||
+            const ImTextureID texture_id = ImmediateMode()
+                ? reinterpret_cast<ImTextureID>(found == textures_.end()
+                      ? nullptr : found->second.d3d11_view.Get())
+                : static_cast<ImTextureID>(
+                      found == textures_.end() ? 0 : found->second.gpu.ptr);
+            if (found == textures_.end() || texture_id == ImTextureID{} ||
                 found->second.device_generation != device_generation_) {
                 return false;
             }
@@ -177,7 +200,7 @@ public:
                 static_cast<float>((tint_rgba >> 16U) & 0xffU) / 255.0F,
                 static_cast<float>((tint_rgba >> 24U) & 0xffU) / 255.0F);
             ImGui::ImageWithBg(
-                static_cast<ImTextureID>(found->second.gpu.ptr),
+                texture_id,
                 ImVec2(resolved_width, resolved_height), ImVec2(0.0F, 0.0F),
                 ImVec2(1.0F, 1.0F), ImVec4(0.0F, 0.0F, 0.0F, 0.0F), tint);
             return true;
@@ -258,7 +281,9 @@ public:
         const std::shared_ptr<anomaly::PluginScope>& scope,
         const anomaly::UiResourceHandle handle) noexcept override {
         try {
-            if (scope == nullptr || !handle || !CanUploadTexture()) return;
+            if (scope == nullptr || !handle || !CanUploadTexture()) {
+                return;
+            }
             const auto resource = registry.ResourceState(scope, handle);
             if (!resource || resource->kind != anomaly::UiResourceKind::Texture ||
                 resource->resource_id == 0) {
@@ -274,7 +299,8 @@ public:
             const std::uint64_t generation = registry.DeviceGeneration();
             if (resource->state == anomaly::UiResourceState::Ready &&
                 resource->device_generation == generation && existing != textures_.end() &&
-                existing->second.device_generation == generation && existing->second.gpu.ptr != 0) {
+                existing->second.device_generation == generation &&
+                existing->second.Resident(ImmediateMode())) {
                 return;
             }
             if (resource->state != anomaly::UiResourceState::Queued &&
@@ -292,7 +318,8 @@ public:
             }
             const std::uint64_t byte_size = state->request.encoded_bytes.size();
             std::uint64_t maximum_upload_bytes{};
-            if (!EstimateTextureUploadBytes(state->request, &maximum_upload_bytes)) {
+            if (!EstimateTextureUploadBytes(
+                    state->request, &maximum_upload_bytes, ImmediateMode())) {
                 static_cast<void>(registry.MarkTextureFailed(scope, handle));
                 return;
             }
@@ -386,20 +413,36 @@ public:
     }
 
 private:
+    // True while the overlay draws through the immediate context, which is the
+    // whole of D3D11 submission: no queue, no fences, no descriptor heaps, and
+    // therefore none of the deferral the D3D12 paths below need.
+    [[nodiscard]] bool ImmediateMode() const noexcept {
+        return state_.render_api == EmbeddedRenderApi::D3D11;
+    }
+
     [[nodiscard]] bool CanTouchImGui() const noexcept {
+        if (state_.imgui_context == nullptr ||
+            ImGui::GetCurrentContext() != state_.imgui_context) {
+            return false;
+        }
+        if (ImmediateMode()) {
+            return state_.dx11_initialized && state_.d3d11_device != nullptr;
+        }
         return state_.dx12_initialized && state_.device != nullptr &&
-            state_.shader_heap != nullptr && state_.imgui_context != nullptr &&
-            ImGui::GetCurrentContext() == state_.imgui_context;
+            state_.shader_heap != nullptr;
     }
 
     [[nodiscard]] bool CanUploadTexture() const noexcept {
-        return CanTouchImGui() && state_.command_list != nullptr &&
-            state_.shader_descriptors.Available() != 0;
+        if (!CanTouchImGui()) return false;
+        if (ImmediateMode()) return true;
+        return state_.command_list != nullptr && state_.shader_descriptors.Available() != 0;
     }
 
     [[nodiscard]] bool CanRebuildFontAtlas() const noexcept {
-        if (!CanTouchImGui() || state_.fence == nullptr ||
-            FAILED(state_.device->GetDeviceRemovedReason())) {
+        if (!CanTouchImGui()) return false;
+        // Nothing is in flight to wait for when submission is immediate.
+        if (ImmediateMode()) return true;
+        if (state_.fence == nullptr || FAILED(state_.device->GetDeviceRemovedReason())) {
             return false;
         }
         const std::uint64_t completed = state_.fence->GetCompletedValue();
@@ -520,15 +563,54 @@ private:
         return marked;
     }
 
+    // Creates an immutable texture directly from the decoded pixels. There is
+    // no staging resource to account for, no copy to record and no fence to
+    // wait on before the view can be drawn with.
+    [[nodiscard]] bool CreateTextureD3D11(
+        TextureEntry& entry, const anomaly::UiTextureRequest& request) noexcept {
+        if (state_.d3d11_device == nullptr) return false;
+        D3D11_TEXTURE2D_DESC description{};
+        description.Width = request.width;
+        description.Height = request.height;
+        description.MipLevels = 1;
+        description.ArraySize = 1;
+        description.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
+        description.SampleDesc.Count = 1;
+        description.Usage = D3D11_USAGE_IMMUTABLE;
+        description.BindFlags = D3D11_BIND_SHADER_RESOURCE;
+        D3D11_SUBRESOURCE_DATA data{};
+        data.pSysMem = request.encoded_bytes.data();
+        data.SysMemPitch = request.width * 4U;
+        if (FAILED(state_.d3d11_device->CreateTexture2D(
+                &description, &data, entry.d3d11_texture.ReleaseAndGetAddressOf()))) {
+            return false;
+        }
+        D3D11_SHADER_RESOURCE_VIEW_DESC view{};
+        view.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
+        view.ViewDimension = D3D11_SRV_DIMENSION_TEXTURE2D;
+        view.Texture2D.MipLevels = 1;
+        if (FAILED(state_.d3d11_device->CreateShaderResourceView(
+                entry.d3d11_texture.Get(), &view,
+                entry.d3d11_view.ReleaseAndGetAddressOf()))) {
+            entry.d3d11_texture.Reset();
+            return false;
+        }
+        entry.upload_byte_size = 0;
+        entry.release_fence = 0;
+        entry.upload_fence = 0;
+        return true;
+    }
+
     [[nodiscard]] bool CreateTexture(
         TextureEntry& entry, const anomaly::UiTextureRequest& request,
         const std::uint64_t maximum_upload_bytes) noexcept {
-        if (state_.device == nullptr || state_.command_list == nullptr || request.width == 0 ||
-            request.height == 0 || request.encoded_bytes.empty() ||
+        if (request.width == 0 || request.height == 0 || request.encoded_bytes.empty() ||
             static_cast<std::uint64_t>(request.width) * request.height * 4U !=
                 request.encoded_bytes.size()) {
             return false;
         }
+        if (ImmediateMode()) return CreateTextureD3D11(entry, request);
+        if (state_.device == nullptr || state_.command_list == nullptr) return false;
 
         D3D12_CPU_DESCRIPTOR_HANDLE cpu{};
         D3D12_GPU_DESCRIPTOR_HANDLE gpu{};
@@ -637,7 +719,12 @@ private:
         if (!font_atlas_dirty_ || !CanRebuildFontAtlas()) return;
 
         ImGuiIO& io = ImGui::GetIO();
-        ImGui_ImplDX12_InvalidateDeviceObjects();
+        const bool immediate = ImmediateMode();
+        if (immediate) {
+            ImGui_ImplDX11_InvalidateDeviceObjects();
+        } else {
+            ImGui_ImplDX12_InvalidateDeviceObjects();
+        }
         static_cast<void>(ConfigurePlatformUiFontAtlas(state_.root));
         bool device_objects_ready = true;
         for (auto& [resource_id, entry] : fonts_) {
@@ -658,7 +745,9 @@ private:
                 entry.failed = false;
             }
         }
-        if (!ImGui_ImplDX12_CreateDeviceObjects()) device_objects_ready = false;
+        const bool created = immediate ? ImGui_ImplDX11_CreateDeviceObjects()
+                                       : ImGui_ImplDX12_CreateDeviceObjects();
+        if (!created) device_objects_ready = false;
         if (device_objects_ready) {
             const std::uint64_t generation = registry.DeviceGeneration();
             device_generation_ = generation;
@@ -681,11 +770,13 @@ private:
     }
 
     [[nodiscard]] bool IsFenceComplete(const TextureEntry& entry) const noexcept {
+        if (ImmediateMode()) return true;
         return entry.release_fence == 0 ||
             (state_.fence != nullptr && state_.fence->GetCompletedValue() >= entry.release_fence);
     }
 
     [[nodiscard]] bool IsUploadFenceComplete(const TextureEntry& entry) const noexcept {
+        if (ImmediateMode()) return true;
         return entry.upload_fence == 0 ||
             (state_.fence != nullptr && state_.fence->GetCompletedValue() >= entry.upload_fence);
     }
@@ -764,6 +855,8 @@ private:
     }
 
     void ReleaseTexture(TextureEntry& entry) noexcept {
+        entry.d3d11_view.Reset();
+        entry.d3d11_texture.Reset();
         if (entry.cpu.ptr != 0 || entry.gpu.ptr != 0) {
             static_cast<void>(state_.shader_descriptors.Free(entry.cpu, entry.gpu));
             entry.cpu = {};

--- a/src/ui/platform_host.cpp
+++ b/src/ui/platform_host.cpp
@@ -13,6 +13,7 @@
 
 #include <Windows.h>
 #include <d3d11.h>
+#include <dwmapi.h>
 #include <shellapi.h>
 
 #include <imgui.h>
@@ -50,6 +51,13 @@ extern "C" IMAGE_DOS_HEADER __ImageBase;
 namespace ue5mem {
 namespace {
 
+// Fully transparent clear colour. Composition takes the swap chain's alpha
+// literally, so clearing to zero alpha leaves the desktop showing through
+// everywhere the panels do not draw. A layered window cannot be used for this:
+// WS_EX_LAYERED redirects the window to a surface the D3D swap chain never
+// reaches, which paints an opaque rectangle instead.
+constexpr float kHostClearColor[4]{0.0f, 0.0f, 0.0f, 0.0f};
+
 struct HostWindow {
     HWND window{};
     HWND target{};
@@ -59,6 +67,13 @@ struct HostWindow {
     ID3D11RenderTargetView* render_target{};
     ID3D11ShaderResourceView* header_logo{};
     std::shared_ptr<std::string> imgui_ini_path;
+    // Whether the compositor honoured the swap chain's alpha. Placement depends
+    // on it: a window that failed to become transparent must stay a small panel
+    // rather than an opaque sheet over the whole game.
+    bool alpha_composited{};
+    // The panel rectangles the window region was last built from. Rebuilding it
+    // every frame would be wasted work; this is what says when it changed.
+    std::vector<std::array<LONG, 4>> region_panels;
     // Keeps the composition-root owner mapped if an in-flight game tick
     // exceeds the bounded host shutdown handoff.
     std::shared_ptr<PluginManager> plugin_owner;
@@ -143,6 +158,56 @@ HWND FindProcessWindow() {
     return candidate.window;
 }
 
+// Restricts the window to the rectangles the overlay actually draws into.
+//
+// A window spanning the whole client area would otherwise swallow every click,
+// including the ones meant for the game. WS_EX_TRANSPARENT looks like the answer
+// but only passes mouse events through for layered windows, and layering
+// redirects the window to a surface a D3D swap chain never presents into. A
+// window region clips hit-testing as well as painting on an ordinary window, so
+// whatever the overlay leaves empty belongs to the game again.
+//
+// Drags survive this because the backend takes the mouse capture on button
+// down, and a captured window keeps receiving input regardless of its region.
+void UpdateHostWindowRegion(HostWindow& host) {
+    if (!host.attached) return;
+    const ImGuiContext* context = ImGui::GetCurrentContext();
+    if (context == nullptr) return;
+    std::vector<std::array<LONG, 4>> panels;
+    for (const ImGuiWindow* window : context->Windows) {
+        if (window == nullptr || !window->WasActive || window->Hidden) continue;
+        if ((window->Flags & ImGuiWindowFlags_ChildWindow) != 0) continue;
+        const ImRect bounds = window->Rect();
+        const std::array<LONG, 4> panel{
+            static_cast<LONG>(std::floor(bounds.Min.x)),
+            static_cast<LONG>(std::floor(bounds.Min.y)),
+            static_cast<LONG>(std::ceil(bounds.Max.x)),
+            static_cast<LONG>(std::ceil(bounds.Max.y))};
+        if (panel[2] <= panel[0] || panel[3] <= panel[1]) continue;
+        panels.push_back(panel);
+    }
+    if (panels == host.region_panels) return;
+    host.region_panels = panels;
+    if (panels.empty()) {
+        // Nothing is being drawn. An empty region would make the window vanish
+        // in a way that also drops the swap chain's output, so keep a single
+        // pixel and leave the rest of the client area to the game.
+        SetWindowRgn(host.window, CreateRectRgn(0, 0, 1, 1), TRUE);
+        return;
+    }
+    HRGN region = CreateRectRgn(panels[0][0], panels[0][1], panels[0][2], panels[0][3]);
+    if (region == nullptr) return;
+    for (std::size_t index = 1; index < panels.size(); ++index) {
+        const auto& panel = panels[index];
+        HRGN addition = CreateRectRgn(panel[0], panel[1], panel[2], panel[3]);
+        if (addition == nullptr) continue;
+        CombineRgn(region, region, addition, RGN_OR);
+        DeleteObject(addition);
+    }
+    // The window manager owns the region from here, so it must not be deleted.
+    if (SetWindowRgn(host.window, region, TRUE) == 0) DeleteObject(region);
+}
+
 bool PlaceAttachedWindow(HostWindow& host) {
     if (!host.attached) return true;
     if (!IsWindow(host.target)) return false;
@@ -152,10 +217,17 @@ bool PlaceAttachedWindow(HostWindow& host) {
     const int client_width = client.right - client.left;
     const int client_height = client.bottom - client.top;
     if (client_width <= 0 || client_height <= 0) return true;
-    const int width = std::max(320, std::min(1080, client_width - 32));
-    const int height = std::max(240, std::min(720, client_height - 32));
-    const int left = origin.x + (client_width - width) / 2;
-    const int top = origin.y + (client_height - height) / 2;
+    // Cover the whole client area once the window is transparent, so panels can
+    // be moved anywhere over the game. Clamping to a centred box was what
+    // confined the panels to one rectangle, which only made sense while the
+    // window was an opaque sheet that would otherwise have hidden the game.
+    const bool full_client = host.alpha_composited;
+    const int width = full_client
+        ? client_width : std::max(320, std::min(1080, client_width - 32));
+    const int height = full_client
+        ? client_height : std::max(240, std::min(720, client_height - 32));
+    const int left = full_client ? origin.x : origin.x + (client_width - width) / 2;
+    const int top = full_client ? origin.y : origin.y + (client_height - height) / 2;
     return SetWindowPos(
                host.window, HWND_TOP, left, top, width, height,
                SWP_NOOWNERZORDER | SWP_NOACTIVATE | SWP_SHOWWINDOW) != FALSE;
@@ -218,6 +290,34 @@ LRESULT WINAPI WindowProc(HWND window, UINT message, WPARAM wparam, LPARAM lpara
 }
 
 void DestroyDevice(HostWindow& host);
+
+// Asks the desktop compositor to honour the swap chain's alpha channel.
+//
+// An empty blur region is the long-standing way to get per-pixel alpha on an
+// ordinary window. The alternative, WS_EX_LAYERED, cannot be used here: it
+// redirects the window onto a surface that a D3D swap chain never presents
+// into, which shows up as an opaque rectangle where the overlay should be.
+//
+// Resolved at run time because the process may be running against the
+// framework's own forwarding dwmapi, and because losing transparency is not
+// worth failing over.
+bool EnableHostWindowTransparency(HWND window) noexcept {
+    if (window == nullptr) return false;
+    using EnableBlurBehind = HRESULT(WINAPI*)(HWND, const DWM_BLURBEHIND*);
+    const HMODULE dwm = LoadLibraryW(L"dwmapi.dll");
+    if (dwm == nullptr) return false;
+    const auto enable_blur_behind =
+        reinterpret_cast<EnableBlurBehind>(GetProcAddress(dwm, "DwmEnableBlurBehindWindow"));
+    if (enable_blur_behind == nullptr) return false;
+    const HRGN region = CreateRectRgn(0, 0, -1, -1);
+    DWM_BLURBEHIND blur{};
+    blur.dwFlags = DWM_BB_ENABLE | DWM_BB_BLURREGION;
+    blur.fEnable = TRUE;
+    blur.hRgnBlur = region;
+    const HRESULT result = enable_blur_behind(window, &blur);
+    if (region != nullptr) DeleteObject(region);
+    return SUCCEEDED(result);
+}
 
 bool CreateDevice(HostWindow& host) {
     DXGI_SWAP_CHAIN_DESC description{};
@@ -832,10 +932,24 @@ public:
         // Keep a consistent margin around the responsive product surface and
         // scale both the viewport bounds and the persisted logical size.
         const float shell_margin = Scaled(kPlatformShellViewportMargin);
-        const float maximum_shell_width = Scaled(kPlatformMaximumShellWidth);
-        const float maximum_shell_height = Scaled(kPlatformMaximumShellHeight);
-        const float minimum_shell_width = Scaled(kPlatformMinimumShellWidth);
-        const float minimum_shell_height = Scaled(kPlatformMinimumShellHeight);
+        // The bounds have to answer to the viewport, not only to the DPI scale.
+        // A 1180x700 surface at 125% asks for 1475x875, which overflows a
+        // 1280x720 client area, and the overflow is silently clipped -- the
+        // shell then looks confined to a box no matter how large the window is.
+        const float available_width =
+            std::max(io.DisplaySize.x - shell_margin * 2.0f, 1.0f);
+        const float available_height =
+            std::max(io.DisplaySize.y - shell_margin * 2.0f, 1.0f);
+        const float maximum_shell_width =
+            std::min(Scaled(kPlatformMaximumShellWidth), available_width);
+        const float maximum_shell_height =
+            std::min(Scaled(kPlatformMaximumShellHeight), available_height);
+        // Kept below the maxima above: a viewport smaller than the minimum
+        // would otherwise hand std::clamp an inverted range.
+        const float minimum_shell_width =
+            std::min(Scaled(kPlatformMinimumShellWidth), maximum_shell_width);
+        const float minimum_shell_height =
+            std::min(Scaled(kPlatformMinimumShellHeight), maximum_shell_height);
         ImVec2 logical_expanded_size = management_shell_expanded_size_;
         if (logical_expanded_size.x <= 0.0f || logical_expanded_size.y <= 0.0f) {
             logical_expanded_size = {
@@ -6829,10 +6943,16 @@ void RunPlatform(
             << "platform window/device creation failed: " << GetLastError() << '\n';
         return;
     }
+    // Makes the desktop compositor honour the swap chain's alpha, so the frame
+    // stops being an opaque rectangle over the game. Failure only costs
+    // transparency, so it is recorded rather than treated as fatal.
+    host.alpha_composited = EnableHostWindowTransparency(host.window);
+    const bool alpha_composited = host.alpha_composited;
     {
         std::ofstream log(root / L"anomaly-platform.log", std::ios::app);
         log << "pid=" << GetCurrentProcessId() << " window=" << host.window
-            << " attached=" << (host.attached ? 1 : 0) << " target=" << host.target << '\n';
+            << " attached=" << (host.attached ? 1 : 0) << " target=" << host.target
+            << " alphaComposited=" << (alpha_composited ? 1 : 0) << '\n';
     }
 
     IMGUI_CHECKVERSION();
@@ -6932,8 +7052,22 @@ void RunPlatform(
                 if (host.attached) PlaceAttachedWindow(host);
                 ShowWindow(host.window, host.attached ? SW_SHOWNOACTIVATE : SW_SHOW);
                 anomaly::SetHostUiMenusCollapsed(false);
+                // The shell's own close button marks the management window
+                // closed and that state is persisted, so without reopening it
+                // here the hotkey would show an empty window forever -- in this
+                // session and in every later one.
+                static_cast<void>(RevealPlatformUi());
+            } else if (!anomaly::HostUiMenusCollapsed()) {
+                anomaly::SetHostUiMenusCollapsed(true);
             } else {
-                anomaly::SetHostUiMenusCollapsed(!anomaly::HostUiMenusCollapsed());
+                // Third state: the window is up but collapsed, so the only thing
+                // left on screen is its own opaque background sitting over the
+                // game. This used to be a dead end -- the hotkey could collapse
+                // the menus but never take the window back down, so the window
+                // stayed on top of the game until it was closed by hand. The
+                // hotkey now completes the cycle.
+                host.visible = false;
+                ShowWindow(host.window, SW_HIDE);
             }
         }
         if (ApplyHostUiManagementExpansionRequest() && !host.visible) {
@@ -6978,9 +7112,9 @@ void RunPlatform(
             plugins.Draw(ImGui::GetCurrentContext());
         }
         ImGui::Render();
-        constexpr float clear_color[4]{0.06f, 0.065f, 0.07f, 1.0f};
+        UpdateHostWindowRegion(host);
         host.context->OMSetRenderTargets(1, &host.render_target, nullptr);
-        host.context->ClearRenderTargetView(host.render_target, clear_color);
+        host.context->ClearRenderTargetView(host.render_target, kHostClearColor);
         ImGui_ImplDX11_RenderDrawData(ImGui::GetDrawData());
         host.swap_chain->Present(1, 0);
         FlushPlatformUiActions();


### PR DESCRIPTION
## 改动概述

- 新增 D3D11 嵌入式渲染路径，同时保留原有 D3D12 路径。
- 修复平台窗口关闭后无法通过快捷键重新打开的问题。
- 为 D3D11 增加字体和纹理资源支持，使平台及插件图标能够正常显示。
- 让独立宿主外壳尺寸受实际视口约束；附加到游戏窗口时覆盖完整客户区，同时仅在 ImGui 面板区域接收点击。
- 新增 D3D11 测试夹具，覆盖真实 DXGI Present 钩子、ResizeBuffers、纹理解码与上传、独立附加窗口模式以及鼠标点击路由。

## 问题原因

嵌入式 Present 钩子位于 DXGI，因此 D3D11 和 D3D12 交换链都会触发它。但原渲染器只实现了 D3D12，并等待通过 `ExecuteCommandLists` 钩子捕获 Direct 命令队列。D3D11 没有命令队列，因此渲染器会一直停留在 `Cold` 状态，无法向插件发布 UI 服务，快捷键也没有可切换的界面。

独立外壳还存在几处相互独立的问题：

- 关闭按钮调用 `CloseWindow` 并持久化 `open=false`，而快捷键只修改折叠状态。
- 外壳尺寸只按 DPI 缩放，没有限制在实际视口以内。
- 即使窗口已经支持透明合成，附加宿主仍被限制在居中的 1080x720 区域内。

## 实现方式

- 从被拦截的交换链判断实际渲染 API，并分别进入 D3D11 或 D3D12 初始化流程。
- D3D11 使用立即上下文和 RTV；ImGui 绘制前后保存并恢复游戏原有的渲染目标。
- 在 `ResizeBuffers` 前释放 D3D11 RTV，完成后重新创建。
- 将嵌入式 UI 资源后端改为同时支持两种 API。D3D11 直接使用解码后的 RGBA 像素创建不可变纹理，并使用 SRV 作为 `ImTextureID`。
- 让纹理常驻判断区分 API，避免 D3D11 纹理每帧被销毁并重建。
- 快捷键展开 UI 时，重新打开已经被持久化关闭的管理窗口。
- 外壳尺寸同时受 DPI 和 ImGui 实际显示区域限制。
- 对支持透明合成的附加宿主使用完整游戏客户区，并根据当前活动的顶层 ImGui 面板矩形设置窗口区域，使面板外的点击传递给游戏。
- 窗口过程替换失败时执行回滚，避免游戏消息被永久转发到 `DefWindowProcW`。
- 增加交换链 API、命令队列捕获状态和渲染启动门控原因的诊断日志。

## 验证结果

- D3D11 夹具能够进入 `Ready`，并显示 `inputHooked=1`，连续呈现 800 帧以上。
- 两次 D3D11 `ResizeBuffers` 往返均返回 `S_OK`。
- 持久化为关闭状态的外壳可以通过快捷键重新打开。
- 在 1280x720 客户区内，外壳矩形由溢出的 1490x890 收敛为 1265x705。
- 附加宿主覆盖目标客户区的比例为 100%。
- 面板外 3 次点击全部到达目标窗口，面板上 2 次点击全部由外壳接收。
- 807 帧期间 D3D11 纹理只创建 1 次，不再每帧重建。
- D3D12 渲染夹具可以通过；其 5 ms p95 预算存在既有波动，纯上游分支也能复现相同的偶发超限。
- 已在上游提交 `fc3373b` 和 `1c2ad3a` 基础上完成完整 RelWithDebInfo 构建，包括新增的 `DllLoader` 目标。