### PR TITLE
fix(plugin): 修复 CombatBox 插件 id 不匹配导致的启动报错

### DIFF
--- a/plugins/CombatBox/plugin.cpp
+++ b/plugins/CombatBox/plugin.cpp
@@ -1084,7 +1084,7 @@ ANOMALY_SDK_EXPORT AnomalyStatusV1 ANOMALY_CALL AnomalyPluginEntryV1(
     }
     *descriptor = {
         sizeof(*descriptor), ANOMALY_PLUGIN_API_V1_MAJOR, ANOMALY_PLUGIN_API_V1_MINOR,
-        anomaly::sdk::StringView("local.combat-box"),
+        anomaly::sdk::StringView("anomaly.local.combat-box"),
         anomaly::sdk::StringView("打怪资源点"),
         anomaly::sdk::StringView("CCYellowStar"),
         anomaly::sdk::StringView("0.1.0"), Load, Start, Stop, Unload, Update, Draw};


### PR DESCRIPTION
## 修复

- 修正 CombatBox 插件描述符 id（`local.combat-box` → `anomaly.local.combat-box`），与 manifest 保持一致。
- 原因：新版框架在加载插件时会校验 manifest id 与 DLL 描述符 id，不一致会报 `plugin identity mismatch`，导致插件启动失败。
- 只改动 `plugins/CombatBox/plugin.cpp` 一行。
